### PR TITLE
Skapar nytt deviceId på extern databas vid inlogg

### DIFF
--- a/src/gov/polisen/ainappen/GetNewDevice.java
+++ b/src/gov/polisen/ainappen/GetNewDevice.java
@@ -22,7 +22,7 @@ public class GetNewDevice {
 	private View rootView;
 	String newDevice = "/newDevice/1/1/1";
 
-	public GetNewDevice(View rootView){
+	public GetNewDevice(View rootView) {
 		this.rootView=rootView;
 		
 		newDevice = "http://christian.cyd.liu.se:1337"+newDevice;
@@ -68,7 +68,7 @@ public class GetNewDevice {
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
-			return null;
+			return 0;
 		}
 
 		@Override

--- a/src/gov/polisen/ainappen/GetNewDevice.java
+++ b/src/gov/polisen/ainappen/GetNewDevice.java
@@ -1,0 +1,84 @@
+package gov.polisen.ainappen;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+import android.os.AsyncTask;
+import android.view.View;
+
+public class GetNewDevice {
+
+	private View rootView;
+	String newDevice = "/newDevice/1/1/1";
+
+	public GetNewDevice(View rootView){
+		this.rootView=rootView;
+		
+		newDevice = "http://christian.cyd.liu.se:1337"+newDevice;
+		
+//		GlobalData appdata = ((GlobalData) rootView.getContext().getApplicationContext());
+//		appdata.getServer()
+		
+		final SyncDB syncer = new SyncDB();
+		syncer.execute(newDevice);
+		
+	}
+
+	private class SyncDB extends AsyncTask<String, Void, Integer> {
+
+		private int responseCode;
+
+		@Override
+		protected Integer doInBackground(String... urls) {
+
+			StringBuilder builder = new StringBuilder();
+			HttpClient client = new DefaultHttpClient();
+			HttpGet httpGet = new HttpGet(urls[0]);
+
+			try {
+				HttpResponse response = client.execute(httpGet);
+				StatusLine statusLine = response.getStatusLine();
+				responseCode = statusLine.getStatusCode();
+				if (responseCode == 200) {
+					HttpEntity entity = response.getEntity();
+					InputStream content = entity.getContent();
+					BufferedReader reader = new BufferedReader(
+							new InputStreamReader(content));
+					String line;
+					while ((line = reader.readLine()) != null) {
+						builder.append(line);
+					}
+					return Integer.parseInt(builder.toString());
+				} else {
+					// error
+				}
+			} catch (ClientProtocolException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		@Override
+		protected void onPostExecute(Integer result) {
+			GlobalData appdata = ((GlobalData) rootView.getContext()
+					.getApplicationContext());
+			appdata.setDeviceID(result);
+
+		}
+
+	}
+
+}

--- a/src/gov/polisen/ainappen/LoginAcitivity.java
+++ b/src/gov/polisen/ainappen/LoginAcitivity.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,7 +28,7 @@ public class LoginAcitivity extends Activity {
 		setContentView(R.layout.activity_login_acitivity);
 		if (savedInstanceState == null) {
 			getFragmentManager().beginTransaction()
-			.add(R.id.container, new PlaceholderFragment()).commit();
+					.add(R.id.container, new PlaceholderFragment()).commit();
 		}
 	}
 
@@ -37,12 +38,12 @@ public class LoginAcitivity extends Activity {
 	@SuppressLint("ValidFragment")
 	public class PlaceholderFragment extends Fragment {
 
-		EditText		userNameText;
-		EditText		passwordText;
-		private Button	quickLogButton;
-		private Button	databaseLoginButton;
-		View			rootView;
-		LoginDBHandler	ldh;
+		EditText userNameText;
+		EditText passwordText;
+		private Button quickLogButton;
+		private Button databaseLoginButton;
+		View rootView;
+		LoginDBHandler ldh;
 
 		public PlaceholderFragment() {
 
@@ -92,8 +93,11 @@ public class LoginAcitivity extends Activity {
 			Random rnd = new Random();
 			int dId = rnd.nextInt(1000000);
 			appData.setUser(new User(dId, userNameText.getText().toString()));
-			//appData.getUser().setUserName((userNameText.getText().toString()));
-			//appData.setDeviceID(dId);
+			Log.d("HELLO", " " + appData.getDeviceID());
+			if (appData.getDeviceID() == 0)
+				new GetNewDevice(rootView);
+			// appData.getUser().setUserName((userNameText.getText().toString()));
+			// appData.setDeviceID(dId);
 			appData.setPassword(passwordText.getText().toString());
 		}
 
@@ -118,8 +122,8 @@ public class LoginAcitivity extends Activity {
 
 		public void makeFailedToast() {
 			String toastMessage = "Fel användarnamn eller lösenord!";
-			Toast.makeText(getActivity(), toastMessage,
-					Toast.LENGTH_LONG).show();
+			Toast.makeText(getActivity(), toastMessage, Toast.LENGTH_LONG)
+					.show();
 		}
 
 		public void textFieldSetter() {

--- a/src/gov/polisen/ainappen/LoginAcitivity.java
+++ b/src/gov/polisen/ainappen/LoginAcitivity.java
@@ -74,9 +74,15 @@ public class LoginAcitivity extends Activity {
 
 		public void checkLogin() {
 			Intent intent = new Intent(getActivity(), MainActivity.class);
-			makeGlobal();
-			ldh.release();
-			startActivity(intent);
+			if (makeGlobal()) {
+				ldh.release();
+				startActivity(intent);
+				finish();
+			} else {
+				Toast.makeText(getApplicationContext(), "Enhet ej registrerad",
+						Toast.LENGTH_SHORT).show();
+			}
+
 		}
 
 		public void cheatLogin() {
@@ -88,17 +94,19 @@ public class LoginAcitivity extends Activity {
 			finish();
 		}
 
-		public void makeGlobal() {
+		public boolean makeGlobal() {
 			final GlobalData appData = ((GlobalData) getApplicationContext());
 			Random rnd = new Random();
 			int dId = rnd.nextInt(1000000);
 			appData.setUser(new User(dId, userNameText.getText().toString()));
 			Log.d("HELLO", " " + appData.getDeviceID());
-			if (appData.getDeviceID() == 0)
+			if (appData.getDeviceID() == 0) {
 				new GetNewDevice(rootView);
+			}
 			// appData.getUser().setUserName((userNameText.getText().toString()));
 			// appData.setDeviceID(dId);
 			appData.setPassword(passwordText.getText().toString());
+			return true;
 		}
 
 		public void setupLoginToDatabaseButtonListener() {


### PR DESCRIPTION
Skapar alltid nytt device när man loggar in med "riktiga" inloggningsuppgifter. Om enheten är offline sätts deviceId till 0.

Löser delvis issue #44 eftersom varje gång du loggar in (ej offline) så får du ett nytt deviceId -> unikt caseId
